### PR TITLE
fix(dependency): missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.8.1",
     "@codemirror/lang-markdown": "^6.2.4",
+    "@codemirror/language": "^6.11.3",
+    "@codemirror/state": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.2",
+    "@codemirror/view": "^6.38.1",
     "codemirror": "^6.0.1",
     "github-markdown-css": "^5.8.1",
     "mermaid": "^11.9.0",


### PR DESCRIPTION
These dependencies are missing in package.json and will cause an error when running the dev server locally.