### PR TITLE
fix: heading decorative bar lost when pasting into WeChat MP editor

### DIFF
--- a/src/core/markdown/social-adapters.js
+++ b/src/core/markdown/social-adapters.js
@@ -198,21 +198,26 @@ function ensureDecorativeSpan(html, tag, config, color) {
     const fontFamilyStyle = extractFontFamilyStyle(cleaned);
     const innerStripped = inner.replace(/^(\s*)<span([^>]*)style=\"([^\"]*?\bwidth\s*:\s*\d+px\b[^\"]*)\"([^>]*)><\/span>(\s*)/i, '$1');
 
+    // Use inline-block instead of display:table/table-cell for WeChat MP compatibility.
+    // WeChat's rich text editor strips display:table-cell during paste, causing the
+    // decorative bar to disappear. inline-block + background is well supported.
+    const heightPx = Math.round(config.heightEm * 20); // convert em to approx px for WeChat compat
     const decoBar = [
-      'display: block;',
+      'display: inline-block;',
+      'vertical-align: middle;',
       `width: ${config.widthPx}px;`,
-      `height: ${config.heightEm}em;`,
+      `height: ${heightPx}px;`,
       `border-radius: ${config.radiusPx}px;`,
       `background: ${color};`,
-      'box-shadow: 0 0 6px rgba(0,0,0,0.08);'
     ].join(' ');
 
-    const containerStyle = 'display: table; width: 100%;';
-    const leftCellStyle = 'display: table-cell; vertical-align: middle; width: 1px;';
-    const rightCellStyle = `display: table-cell; vertical-align: middle; padding-left: 0.5em; ${fontFamilyStyle}`;
+    const textStyle = `display: inline; vertical-align: middle; padding-left: 0.5em; ${fontFamilyStyle}`;
 
-    const content = `<span style=\"${leftCellStyle}\"><span style=\"${decoBar}\">&#8203;</span></span><span style=\"${rightCellStyle}\">${innerStripped}</span>`;
-    return `<${tag}${pre}style=\"${cleaned}; ${containerStyle}\"${post}>${content}</${tag}>`;
+    // Remove width:100% from data-wx-lh-wrap spans inside headings to prevent line break
+    const innerFixed = innerStripped.replace(/(<span[^>]*data-wx-lh-wrap[^>]*style="[^"]*)width:\s*100%[;]?/gi, '$1');
+
+    const content = `<span style=\"${decoBar}\">&nbsp;</span><span style=\"${textStyle}\">${innerFixed}</span>`;
+    return `<${tag}${pre}style=\"${cleaned}\"${post}>${content}</${tag}>`;
   });
 }
 

--- a/tests/core/markdown/post-processors.test.js
+++ b/tests/core/markdown/post-processors.test.js
@@ -71,7 +71,8 @@ describe('adapters.js', () => {
     it('H2/H3/H4 装饰布局应保留父级字体', () => {
       const html = '<h2 style="font-family: \'Kaiti SC\', \'STKaiti\', \'华文楷体\', KaiTi, \'楷体\', serif !important;">二级标题</h2>'
       const result = adapter.transform(html, baseCtx)
-      expect(result).toContain('display: table-cell')
+      expect(result).toContain('display: inline-block')
+      expect(result).toContain('vertical-align: middle')
       expect(result).toContain("font-family: 'Kaiti SC', 'STKaiti', '华文楷体', KaiTi, '楷体', serif !important;")
     })
 


### PR DESCRIPTION
## Problem

When copying formatted content from mdeditor and pasting it into the WeChat Official Account (公众号) editor, the heading decorative bar (colored vertical line on the left side of h2/h3/h4) disappears entirely.

### Screenshots

**Before fix (bar missing in WeChat):**

The decorative bar is visible in mdeditor preview but lost after pasting into WeChat MP editor.

## Root Cause

Three issues in `ensureDecorativeSpan()` within `social-adapters.js`:

1. **`display: table-cell` stripped by WeChat** — The bar and text were laid out using `display: table` / `display: table-cell`, which WeChat's paste sanitizer removes.

2. **Bar height collapses** — The bar used `em` units with a zero-width space (`&#8203;`) as content. After WeChat strips the table layout, the span can collapse to zero height.

3. **`width: 100%` on inner wrap span** — `wrapInner()` injects a `data-wx-lh-wrap` span with `width: 100%` inside headings, pushing the text below the bar onto a new line.

## Fix

- Replace `display: table / table-cell` with `display: inline-block` + `vertical-align: middle` (well-supported by WeChat's sanitizer)
- Convert height from `em` to fixed `px` and use `&nbsp;` instead of `&#8203;` to prevent height collapse
- Strip `width: 100%` from `data-wx-lh-wrap` spans inside decorated headings so bar and text stay on the same line
- Remove `box-shadow` (stripped by WeChat anyway, reduces noise)

## Changes

- `src/core/markdown/social-adapters.js` — `ensureDecorativeSpan()` rewrite
- `tests/core/markdown/post-processors.test.js` — Update assertion to match new output

## Testing

- ✅ All 434 existing tests pass
- ✅ Manually verified: paste into WeChat MP editor preserves the decorative bar inline with heading text